### PR TITLE
Update EnvInject Lib to 1.26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>org.jenkins-ci.lib</groupId>
       <artifactId>envinject-lib</artifactId>
-      <version>1.25</version>
+      <version>1.26</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
I need to respin the plugin release, because the recent upload has been corrupted somehow (no HPI). So I am just bundling a useful change in EnvInject lib with FindBugs cleanup and some API restrictions.

Changelog: https://github.com/jenkinsci/envinject-lib/blob/master/CHANGELOG.md#126

Full diff: https://github.com/jenkinsci/envinject-lib/compare/envinject-lib-1.25...envinject-lib-1.26

@reviewbybees @daniel-beck 