### PR TITLE
[JENKINS-46479] - Update to EnvInject Lib 1.27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.26</version>
+    <version>2.36</version>
   </parent>
 
   <artifactId>envinject-api</artifactId>
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>org.jenkins-ci.lib</groupId>
       <artifactId>envinject-lib</artifactId>
-      <version>1.26</version>
+      <version>1.26-20171006.214254-1</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>org.jenkins-ci.lib</groupId>
       <artifactId>envinject-lib</artifactId>
-      <version>1.26-20171006.214254-1</version>
+      <version>1.27</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Also picks new Parent POM

Integrated changes:
* [JENKINS-46479](https://issues.jenkins-ci.org/browse/JENKINS-46479) - Prevent environment variables from being deleted on existing builds
* Parent POM and FindBugs cleanup: https://github.com/jenkinsci/envinject-lib/pull/12

Upstream PRs:
* https://github.com/jenkinsci/envinject-lib/pull/12

Downstream PRs:
* https://github.com/jenkinsci/envinject-plugin/pull/126