### PR TITLE
getEnvInjectAction() change

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/envinjectapi/util/EnvInjectActionRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/envinjectapi/util/EnvInjectActionRetriever.java
@@ -51,7 +51,7 @@ public class EnvInjectActionRetriever {
             LOGGER.log(Level.WARNING, "There was a problem in the invocation of getParentBuild in hudson.matrix.MatrixRun", e);
         }
 
-        List<Action> actions = run.getActions();
+        List<? extends Action> actions = run.getAllActions();
         for (Action action : actions) {
             if (action == null) {
                 continue;


### PR DESCRIPTION
A new pull request which has only the change getEnvInjectAction. But from my point of view it will not really change the interface. It still returns an action, although it uses internally a List of Actions or classes which extend the Action class. 