### PR TITLE
Plugin pom update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 *.iws
 *.iml
 work
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.47</version>
+    <version>4.6</version>
     <relativePath />
   </parent>
 
@@ -34,7 +34,7 @@
 
   <properties>
     <java.level>8</java.level>
-    <jenkins.version>2.138.4</jenkins.version>
+    <jenkins.version>2.204.1</jenkins.version>
   </properties>
 
   <scm>

--- a/src/main/java/org/jenkinsci/plugins/envinjectapi/util/EnvVarsResolver.java
+++ b/src/main/java/org/jenkinsci/plugins/envinjectapi/util/EnvVarsResolver.java
@@ -78,7 +78,7 @@ public class EnvVarsResolver {
         }
 
         // Retrieve node used for this build
-        Node builtOn = (run instanceof AbstractBuild) ? ((AbstractBuild)run).getBuiltOn() : null;
+        Node builtOn = (run instanceof AbstractBuild) ? ((AbstractBuild<?,?>)run).getBuiltOn() : null;
         
         // Check if node is always on. Otherwise, gather master env vars
         if (builtOn == null) {
@@ -172,7 +172,7 @@ public class EnvVarsResolver {
         if (jenkins != null) {
             DescribableList<NodeProperty<?>, NodePropertyDescriptor> globalNodeProperties = jenkins.getGlobalNodeProperties();
             if (globalNodeProperties != null) {
-                for (NodeProperty nodeProperty : globalNodeProperties) {
+                for (NodeProperty<?> nodeProperty : globalNodeProperties) {
                     if (nodeProperty instanceof EnvironmentVariablesNodeProperty) {
                         env.putAll(((EnvironmentVariablesNodeProperty) nodeProperty).getEnvVars());
                     }
@@ -182,7 +182,7 @@ public class EnvVarsResolver {
 
         if (node != null) {
             DescribableList<NodeProperty<?>, NodePropertyDescriptor> nodeProperties = node.getNodeProperties();
-            for (NodeProperty nodeProperty : nodeProperties) {
+            for (NodeProperty<?> nodeProperty : nodeProperties) {
                 if (nodeProperty instanceof EnvironmentVariablesNodeProperty) {
                     EnvVars envVars = ((EnvironmentVariablesNodeProperty) nodeProperty).getEnvVars();
                     if (envVars != null) {
@@ -224,7 +224,7 @@ public class EnvVarsResolver {
             envVars.put("NODE_LABELS", Util.join(node.getAssignedLabels(), " "));
             
             if (job instanceof AbstractProject) {
-                FilePath wFilePath = ((AbstractProject)job).getSomeWorkspace();
+                FilePath wFilePath = ((AbstractProject<?,?>)job).getSomeWorkspace();
                 if (wFilePath != null) {
                     envVars.put("WORKSPACE", wFilePath.getRemote());
                 }


### PR DESCRIPTION
Originally I just wanted to check if there are open spotbugs warnings, as suggested here [JENKINS-45055](https://issues.jenkins-ci.org/browse/JENKINS-45055)
But I ended with housekeeping, since there are no open spotbugs issues:
* updated plugin pom to 4.6
* updated minimum jenkins version to 2.204.1 since 83% of users of the lastest version are using this or a newer version [pluginversions stats](https://stats.jenkins.io/pluginversions/envinject-api.html)
* added `.idea` to .gitignore
* fixed raw use of parameterized classes